### PR TITLE
Add 'oneof' support

### DIFF
--- a/lib/Google/ProtocolBuffers/CodeGen.pm
+++ b/lib/Google/ProtocolBuffers/CodeGen.pm
@@ -112,6 +112,19 @@ sub generate_code_of_message_or_group {
 FIELD
     }
 
+    my $oneofs_text = "            undef,";
+    if ($self->can('_pb_oneofs')) {
+        $oneofs_text = "            {";
+        while (my ($name, $fields) = each %{$self->_pb_oneofs}) {
+            $oneofs_text .= "                '$name' => [";
+            foreach my $f (@$fields) {
+                $oneofs_text .= "                    '$f',";
+            }
+            $oneofs_text .= "                ],";
+        }
+        $oneofs_text .= "            },";
+    }
+
     my $options = '';
     foreach my $opt_name (qw/create_accessors follow_best_practice/) {
         if ($opts->{$opt_name}) {
@@ -126,6 +139,7 @@ FIELD
             [
 $fields_text
             ],
+$oneofs_text
             { $options }
         );
     }

--- a/lib/Google/ProtocolBuffers/CodeGen.pm
+++ b/lib/Google/ProtocolBuffers/CodeGen.pm
@@ -112,17 +112,17 @@ sub generate_code_of_message_or_group {
 FIELD
     }
 
-    my $oneofs_text = "            undef,";
+    my $oneofs_text = "            undef,\n";
     if ($self->can('_pb_oneofs')) {
-        $oneofs_text = "            {";
+        $oneofs_text = "            {\n";
         while (my ($name, $fields) = each %{$self->_pb_oneofs}) {
-            $oneofs_text .= "                '$name' => [";
+            $oneofs_text .= "                '$name' => [\n";
             foreach my $f (@$fields) {
-                $oneofs_text .= "                    '$f',";
+                $oneofs_text .= "                    '$f',\n";
             }
-            $oneofs_text .= "                ],";
+            $oneofs_text .= "                ],\n";
         }
-        $oneofs_text .= "            },";
+        $oneofs_text .= "            },\n";
     }
 
     my $options = '';

--- a/lib/Google/ProtocolBuffers/Constants.pm
+++ b/lib/Google/ProtocolBuffers/Constants.pm
@@ -55,6 +55,7 @@ BEGIN
         MESSAGE => 1,
         GROUP   => 2,
         ENUM    => 3,
+        ONEOF   => 4,
     };
 }
 

--- a/t/14-oneof.t
+++ b/t/14-oneof.t
@@ -1,0 +1,32 @@
+use Test::More tests => 11;
+use strict;
+use warnings;
+use Google::ProtocolBuffers;
+
+BEGIN{ $SIG{__DIE__} = \&Carp::confess; }
+
+my @classes;
+
+@classes = Google::ProtocolBuffers->parse("
+  package my.test;
+  message TestOneof {
+    oneof test_oneof {
+      string name = 1;
+      int32 serial_number = 2;
+    }
+  }", {create_accessors=>1});
+
+is(scalar @classes, 1);
+is($classes[0], 'My::Test::TestOneof');
+can_ok($classes[0], qw(which_oneof));
+
+my $obj1 = new_ok($classes[0]);
+ok(!defined($obj1->which_oneof('test_oneof')));
+$obj1->name('My Name');
+ok($obj1->name() eq 'My Name');
+ok($obj1->which_oneof('test_oneof') eq 'name');
+ok(!exists($obj1->{'serial_number'}));
+$obj1->serial_number(12345);
+ok($obj1->serial_number() == 12345);
+ok($obj1->which_oneof('test_oneof') eq 'serial_number');
+ok(!exists($obj1->{'name'}));


### PR DESCRIPTION
This change adds support for 'oneof' protobuf fields. The new 'which_oneof' method will return which oneof field is currently filled (or undef if none of the fields are populated).  Setting a oneof field will clear other oneof fields.