### PR TITLE
Backcompat for older create_message() uses

### DIFF
--- a/lib/Google/ProtocolBuffers.pm
+++ b/lib/Google/ProtocolBuffers.pm
@@ -218,6 +218,17 @@ sub create_message {
     my $fields = shift;
     my $oneofs = shift;
     my $opts = shift;
+    if ( !$opts && $oneofs && ref($oneofs) eq 'HASH' ) {
+        # Backcompat; originally the interface here has
+        #   create_message($class, $fields, $opts)
+        # but was later changed to
+        #   create_message($class, $fields, $oneofs, $opts);
+        # Which breaks existing users; luckily $oneofs
+        # is supposed to be an arrayref, so we can detect this
+        # and handle it.
+        $opts   = $oneofs;
+        $oneofs = undef;
+    }
     
     return $self->_create_message_or_group(
         $class_name, $fields, $oneofs, $opts,


### PR DESCRIPTION
create_message()'s API slightly changed a couple of years ago,
from this:

    create_message($class, $fields, $opts)

To this:

    create_message($class, $fields, $oneofs, $opts)

Because $oneofs is an arrayref, any existing users passing $opts
just get an error.

This commit is introducing a minor backcompat layer; if
$oneofs was provided as is a hashref, and $opts was
not provided, then switch them around.